### PR TITLE
Integrate API for fetching ongoing events using existing api.js

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -47,3 +47,17 @@ export const login = async (email, password) => {
 export const getOAuth2LoginUrl = (provider) => {
   return `${API_ORIGIN}/oauth2/authorization/${provider}`;
 };
+
+/**
+ * 진행 중인 이벤트 목록을 가져오는 함수.
+ * @returns {Promise} 진행 중인 이벤트 목록 또는 오류
+ */
+export const fetchOngoingEvents = async () => {
+  try {
+    const response = await axios.get(`${API_ORIGIN}/api/events/ongoing`);
+    return response.data.events;  // 필요한 데이터 형식에 따라 조정
+  } catch (error) {
+    console.error('Failed to fetch ongoing events:', error);
+    throw error;
+  }
+};

--- a/src/stores/eventStore.js
+++ b/src/stores/eventStore.js
@@ -1,6 +1,6 @@
-// src/store/eventStore.js
+// src/stores/eventStore.js
 import create from 'zustand';
-import axios from 'axios';
+import { fetchOngoingEvents } from '../api/api';
 
 const useEventStore = create((set) => ({
   events: [],
@@ -9,8 +9,8 @@ const useEventStore = create((set) => ({
   fetchEvents: async () => {
     set({ loading: true, error: null });
     try {
-      const response = await axios.get('/api/events/ongoing');  // API 엔드포인트 수정 필요
-      set({ events: response.data.events, loading: false });
+      const events = await fetchOngoingEvents();  // API 호출
+      set({ events, loading: false });
     } catch (err) {
       set({ error: err.message, loading: false });
     }


### PR DESCRIPTION
진행 중인 이벤트 목록을 가져오기 위해 기존의 `api.js` 파일을 확장하여 API 호출 기능을 추가했습니다. `fetchOngoingEvents` 함수를 추가하여 진행 중인 이벤트 목록을 가져오는 API를 호출하고, Zustand 상태 관리 스토어에서 이 함수를 사용하여 상태를 업데이트합니다.

변경 사항:
- 진행 중인 이벤트 목록을 가져오는 `fetchOngoingEvents` 함수 추가
- Zustand 상태 관리 스토어에서 API 호출 및 상태 업데이트 기능 추가